### PR TITLE
Add the image_tag_parameter on the service configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ For each service you must provide the following values:
 - `dockerfile`: (optional) the path to dockerfile to use for the service, relative to the `directory` of the service
 - `scripts`: (optional) an object containing global scripts override. It is possibile to override only the bundle script
   - `bundle` is ran right before the docker build, and receives in input the service name. It is executed instead of global bundle script. The path is relative to the service directory and it is executed in the service directory
+- `image_tag_parameter`: (optional) it's possible to override the argo parameter for the image tag (default is `image.tag`)
 
 If all your services use the same dockerfile, you can specify it inside the `docker` key, as `dockerfile`.
 This must be a path relative to the root directory of your project.
@@ -98,6 +99,7 @@ This must be a path relative to the root directory of your project.
 ### Complete configuration example
 
 A complete configuration looks something like this:
+
 ```json
 {
   "default_environment": "dev",
@@ -131,6 +133,16 @@ A complete configuration looks something like this:
       "directory": "./services/street-corners/",
       "service_name": "street-corners",
       "image_name": "street-corners"
+    },
+    "my-other-service": {
+      "directory": "./services/my-other-service/",
+      "service_name": "my-other-service",
+      "image_name": "my-other-service",
+      "dockerfile": "./my-other-service.Dockerfile",
+      "scripts": {
+        "bundle": "./my-other-service-bundle.sh"
+      },
+      "image_tag_parameter": "image.myservice.tag"
     }
   }
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -66,7 +66,7 @@ var buildCmd = &cobra.Command{
 
 		if buildConfig.deploy {
 			for _, service := range services {
-				err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env)
+				err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service))
 				checkNoError(err)
 			}
 		}

--- a/cmd/build_all.go
+++ b/cmd/build_all.go
@@ -52,7 +52,7 @@ var buildAllCmd = &cobra.Command{
 
 		if buildConfig.deploy {
 			for _, service := range config.GetAllServices() {
-				err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env)
+				err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service))
 				checkNoError(err)
 			}
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -39,7 +39,7 @@ var deployCmd = &cobra.Command{
 					continue
 				}
 			}
-			err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env)
+			err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service))
 			checkNoError(err)
 		}
 	},

--- a/cmd/deploy_all.go
+++ b/cmd/deploy_all.go
@@ -34,7 +34,7 @@ var deployAllCmd = &cobra.Command{
 					continue
 				}
 			}
-			err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env)
+			err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service))
 			checkNoError(err)
 		}
 	},

--- a/config/service.go
+++ b/config/service.go
@@ -19,6 +19,10 @@ func GetImageName(service Service) ImageName {
 	return Config.Services[service].ImageName
 }
 
+func GetImageTagParameter(service Service) string {
+	return Config.Services[service].ImageTagParameter
+}
+
 func GetAllServices() []Service {
 	res := make([]Service, 0, len(Config.Services))
 

--- a/config/structure.go
+++ b/config/structure.go
@@ -44,11 +44,12 @@ type ScriptsConfiguration struct {
 }
 
 type ServiceConfiguration struct {
-	Directory   string               `json:"directory"`
-	ServiceName ServiceName          `json:"service_name"`
-	ImageName   ImageName            `json:"image_name"`
-	Scripts     ScriptsConfiguration `json:"scripts"`
-	Dockerfile  string               `json:"dockerfile"`
+	Directory         string               `json:"directory"`
+	ServiceName       ServiceName          `json:"service_name"`
+	ImageName         ImageName            `json:"image_name"`
+	Scripts           ScriptsConfiguration `json:"scripts"`
+	Dockerfile        string               `json:"dockerfile"`
+	ImageTagParameter string               `json:"image_tag_parameter"`
 }
 
 type ArgoEnvironmentConfiguration struct {


### PR DESCRIPTION
With this PR it's possible to add a params on the service configuration called `image_tag_parameter`.
This params is used to override the default parameter used by Argo to identify the image tag (`image.tag`).
If no parameters is defined, the service will use the default `image.tag`.

I also add another service in the deploy1.json on the example, with all the optionals parameter (don't want to add them on the first service to make it clear that everything works fine without them).

We also need to add some task to define test and execute, because there are no test at the moment