### PR TITLE
Add argocli_extra_params to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ A complete configuration looks something like this:
     "environments": {
       "dev": {
         "auth_token": "ARGOCD_AUTH_TOKEN_DEV",
-        "server": "argo.myproject.it"
+        "server": "argo.myproject.it",
+        "service_prefix": "my-prefix",
+        "argocli_extra_params": ["--extra", "--params"]
       }
     }
   },

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -85,11 +85,7 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 
 	cmd.Env = append(os.Environ(), customEnv...)
 
-	log.Debugf("running command  %s", cmd.String())
-
 	res, err := cmd.Output()
-
-	log.Debugf("output:\n%s", string(res))
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current tag: %w", err)

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -61,16 +61,21 @@ type serviceInfo struct {
 }
 
 func getServiceInfo(service config.ServiceName, env config.Environment, customImageTagParameter string) (*serviceInfo, error) {
-	cmd := exec.Command(
-		"argocd",
+	extraParams := config.Config.Argo.Environments[env].ArgoExtraParams
+
+	cmdParams := append([]string{
 		"--grpc-web",
 		"app",
 		"get",
 		string(service),
 		"show-params",
 		"-o", "json",
-		"--plaintext",
-		"--loglevel=debug",
+	},
+		extraParams...)
+
+	cmd := exec.Command(
+		"argocd",
+		cmdParams...,
 	)
 
 	customEnv := []string{
@@ -133,8 +138,9 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 }
 
 func restart(service config.ServiceName, env config.Environment, kind resourceKind) error {
-	cmd := exec.Command(
-		"argocd",
+	extraParams := config.Config.Argo.Environments[env].ArgoExtraParams
+
+	cmdParams := append([]string{
 		"--grpc-web",
 		"app",
 		"actions",
@@ -143,8 +149,12 @@ func restart(service config.ServiceName, env config.Environment, kind resourceKi
 		"restart",
 		"--kind", string(kind),
 		"--all",
-		"--insecure",
-		"--plaintext",
+	},
+		extraParams...)
+
+	cmd := exec.Command(
+		"argocd",
+		cmdParams...,
 	)
 	customEnv := []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
@@ -170,15 +180,20 @@ func deploy(service config.ServiceName, tag string, env config.Environment, cust
 	if customImageTagParameter != "" {
 		imageTagParameter = parameterName(customImageTagParameter)
 	}
-	cmd := exec.Command(
-		"argocd",
+
+	extraParams := config.Config.Argo.Environments[env].ArgoExtraParams
+
+	cmdParams := append([]string{
 		"--grpc-web",
 		"app",
 		"set",
 		string(service),
 		"--helm-set-string", fmt.Sprintf("%s=%s", imageTagParameter, tag),
-		"--insecure",
-		"--plaintext",
+	},
+		extraParams...)
+	cmd := exec.Command(
+		"argocd",
+		cmdParams...,
 	)
 	customEnv := []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -81,10 +81,10 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 
 	res, err := cmd.Output()
 
+	log.Debugf("output:\n%s", string(res))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current tag: %w", err)
 	}
-	log.Debugf("output:\n%s", string(res))
 
 	var response argoParams
 

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -1,6 +1,7 @@
 package argo
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/moveaxlab/deploy1/config"
@@ -78,14 +79,20 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 		fmt.Sprintf("ARGOCD_SERVER=%s", config.Config.Argo.Environments[env].ServerName),
 	}
 
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
+	var out, errb bytes.Buffer
 
-	log.Debugf("running command %s", cmd.String())
+	cmd.Stderr = &out
+	cmd.Stdout = &errb
+
+	log.Debugf("running command  %s", cmd.String())
 
 	res, err := cmd.Output()
 
 	log.Debugf("output:\n%s", string(res))
+
+	log.Debugf("Stdout %s", out.String())
+	log.Debugf("Stderr %s", errb.String())
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current tag: %w", err)
 	}

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -77,6 +77,10 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
 		fmt.Sprintf("ARGOCD_SERVER=%s", config.Config.Argo.Environments[env].ServerName),
 	}
+
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
 	log.Debugf("running command %s", cmd.String())
 
 	res, err := cmd.Output()

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -71,6 +71,7 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 		"-o", "json",
 		"--insecure",
 		"--plaintext",
+		"--loglevel=debug",
 	)
 	cmd.Env = []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
@@ -78,8 +79,6 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 	}
 	log.Debugf("running command %s", cmd.String())
 
-	cmd.Stderr = output.ErrLogger{}
-	cmd.Stdout = output.OutLogger{}
 	res, err := cmd.Output()
 
 	if err != nil {

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -79,8 +79,9 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 	log.Debugf("running command %s", cmd.String())
 
 	res, err := cmd.Output()
-
+	out, _ := cmd.CombinedOutput()
 	if err != nil {
+		log.Infof("Output of command %s", string(out))
 		return nil, fmt.Errorf("failed to get current tag: %w", err)
 	}
 	log.Debugf("output:\n%s", string(res))

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -80,16 +80,9 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 
 	cmd.Env = append(os.Environ(), customEnv...)
 
-	log.Debugf("ENV var ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable))
-	log.Debugf("ENV var HTTP_PROXY=%s", os.Getenv("HTTP_PROXY"))
-
-	for _, s := range cmd.Env {
-		log.Debugf("ENV var %s", s)
-	}
-
 	log.Debugf("running command  %s", cmd.String())
 
-	res, err := cmd.CombinedOutput()
+	res, err := cmd.Output()
 
 	log.Debugf("output:\n%s", string(res))
 
@@ -153,10 +146,12 @@ func restart(service config.ServiceName, env config.Environment, kind resourceKi
 		"--insecure",
 		"--plaintext",
 	)
-	cmd.Env = []string{
+	customEnv := []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
 		fmt.Sprintf("ARGOCD_SERVER=%s", config.Config.Argo.Environments[env].ServerName),
 	}
+
+	cmd.Env = append(os.Environ(), customEnv...)
 	cmd.Stdout = output.OutLogger{}
 	cmd.Stderr = output.ErrLogger{}
 	log.Debugf("running command %s", cmd.String())
@@ -185,10 +180,13 @@ func deploy(service config.ServiceName, tag string, env config.Environment, cust
 		"--insecure",
 		"--plaintext",
 	)
-	cmd.Env = []string{
+	customEnv := []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
 		fmt.Sprintf("ARGOCD_SERVER=%s", config.Config.Argo.Environments[env].ServerName),
 	}
+
+	cmd.Env = append(os.Environ(), customEnv...)
+
 	cmd.Stdout = output.OutLogger{}
 	cmd.Stderr = output.ErrLogger{}
 	log.Debugf("running command %s", cmd.String())

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -78,10 +78,11 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 	}
 	log.Debugf("running command %s", cmd.String())
 
+	cmd.Stderr = output.ErrLogger{}
+	cmd.Stdout = output.OutLogger{}
 	res, err := cmd.Output()
-	out, _ := cmd.CombinedOutput()
+
 	if err != nil {
-		log.Infof("Output of command %s", string(out))
 		return nil, fmt.Errorf("failed to get current tag: %w", err)
 	}
 	log.Debugf("output:\n%s", string(res))

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -1,7 +1,6 @@
 package argo
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/moveaxlab/deploy1/config"
@@ -79,8 +78,6 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 		fmt.Sprintf("ARGOCD_SERVER=%s", config.Config.Argo.Environments[env].ServerName),
 		fmt.Sprintf("HTTP_PROXY=%s", os.Getenv("HTTP_PROXY")),
 	}
-
-	var out, errb bytes.Buffer
 
 	log.Debugf("running command  %s", cmd.String())
 

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -77,21 +77,16 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 	cmd.Env = []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
 		fmt.Sprintf("ARGOCD_SERVER=%s", config.Config.Argo.Environments[env].ServerName),
+		fmt.Sprintf("HTTP_PROXY=%s", os.Getenv("HTTP_PROXY")),
 	}
 
 	var out, errb bytes.Buffer
-
-	cmd.Stderr = &out
-	cmd.Stdout = &errb
 
 	log.Debugf("running command  %s", cmd.String())
 
 	res, err := cmd.Output()
 
 	log.Debugf("output:\n%s", string(res))
-
-	log.Debugf("Stdout %s", out.String())
-	log.Debugf("Stderr %s", errb.String())
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current tag: %w", err)

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -70,6 +70,7 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 		"show-params",
 		"-o", "json",
 		"--insecure",
+		"--plaintext",
 	)
 	cmd.Env = []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
@@ -138,6 +139,7 @@ func restart(service config.ServiceName, env config.Environment, kind resourceKi
 		"--kind", string(kind),
 		"--all",
 		"--insecure",
+		"--plaintext",
 	)
 	cmd.Env = []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
@@ -169,6 +171,7 @@ func deploy(service config.ServiceName, tag string, env config.Environment, cust
 		string(service),
 		"--helm-set-string", fmt.Sprintf("%s=%s", imageTagParameter, tag),
 		"--insecure",
+		"--plaintext",
 	)
 	cmd.Env = []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -76,7 +76,13 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 	cmd.Env = []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
 		fmt.Sprintf("ARGOCD_SERVER=%s", config.Config.Argo.Environments[env].ServerName),
-		fmt.Sprintf("HTTP_PROXY=%s", os.Getenv("HTTP_PROXY")),
+	}
+
+	log.Debugf("ENV var ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable))
+	log.Debugf("ENV var HTTP_PROXY=%s", os.Getenv("HTTP_PROXY"))
+
+	for _, s := range cmd.Env {
+		log.Debugf("ENV var %s", s)
 	}
 
 	log.Debugf("running command  %s", cmd.String())

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -69,6 +69,7 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 		string(service),
 		"show-params",
 		"-o", "json",
+		"--insecure",
 	)
 	cmd.Env = []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
@@ -136,6 +137,7 @@ func restart(service config.ServiceName, env config.Environment, kind resourceKi
 		"restart",
 		"--kind", string(kind),
 		"--all",
+		"--insecure",
 	)
 	cmd.Env = []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
@@ -166,6 +168,7 @@ func deploy(service config.ServiceName, tag string, env config.Environment, cust
 		"set",
 		string(service),
 		"--helm-set-string", fmt.Sprintf("%s=%s", imageTagParameter, tag),
+		"--insecure",
 	)
 	cmd.Env = []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -69,14 +69,16 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 		string(service),
 		"show-params",
 		"-o", "json",
-		"--insecure",
 		"--plaintext",
 		"--loglevel=debug",
 	)
-	cmd.Env = []string{
+
+	customEnv := []string{
 		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
 		fmt.Sprintf("ARGOCD_SERVER=%s", config.Config.Argo.Environments[env].ServerName),
 	}
+
+	cmd.Env = append(os.Environ(), customEnv...)
 
 	log.Debugf("ENV var ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable))
 	log.Debugf("ENV var HTTP_PROXY=%s", os.Getenv("HTTP_PROXY"))
@@ -87,7 +89,7 @@ func getServiceInfo(service config.ServiceName, env config.Environment, customIm
 
 	log.Debugf("running command  %s", cmd.String())
 
-	res, err := cmd.Output()
+	res, err := cmd.CombinedOutput()
 
 	log.Debugf("output:\n%s", string(res))
 

--- a/config/structure.go
+++ b/config/structure.go
@@ -53,9 +53,10 @@ type ServiceConfiguration struct {
 }
 
 type ArgoEnvironmentConfiguration struct {
-	AuthTokenEnvVariable string `json:"auth_token"`
-	ServerName           string `json:"server"`
-	ServicePrefix        string `json:"service_prefix"`
+	AuthTokenEnvVariable string   `json:"auth_token"`
+	ServerName           string   `json:"server"`
+	ServicePrefix        string   `json:"service_prefix"`
+	ArgoExtraParams      []string `json:"argocli_extra_params"`
 }
 
 type ArgoConfiguration struct {


### PR DESCRIPTION
This PR add a configuration field on the argo environments called `argocli_extra_params`.
The type is an array, and you can pass any extra param to be put on the argocd command used by deploy1.
Also it add the `os.Environ()` context to the command, in order to access any usefull env var.