### PR TITLE
add option to check from the terminal when deployment is up and running

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,20 @@ If you don't specify an environment, the `default_environment` will be used.
 
 You can also deploy all services with `deploy1 deploy-all`.
 
+#### Waiting for deployment completion
+
+You can wait for the service to be fully deployed (synced and healthy) using the `--wait` flag:
+
+```bash
+deploy1 deploy --wait <service 1> <service 2> ...
+```
+
+When the `--wait` flag is used, deploy1 will:
+- Deploy the service as usual
+- Wait for the service to be completely synced and healthy in ArgoCD
+- Report when the service is ready
+
+It can also be used in combination with deploy flag when doing a build and deploy in one shot.
 ## Extras
 
 There's an attempt at support for shell completion.

--- a/argo/deploy.go
+++ b/argo/deploy.go
@@ -3,11 +3,12 @@ package argo
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+
 	"github.com/moveaxlab/deploy1/config"
 	"github.com/moveaxlab/deploy1/output"
 	log "github.com/sirupsen/logrus"
-	"os"
-	"os/exec"
 )
 
 type parameterName string
@@ -211,7 +212,43 @@ func deploy(service config.ServiceName, tag string, env config.Environment, cust
 	return nil
 }
 
-func Deploy(service config.ServiceName, tag string, env config.Environment, imageTagParameter string) error {
+func wait(service config.ServiceName, env config.Environment) error {
+	extraParams := config.Config.Argo.Environments[env].ArgoExtraParams
+
+	cmdParams := append([]string{
+		"--grpc-web",
+		"app",
+		"wait",
+		string(service),
+		"--health",
+		"--sync",
+	},
+		extraParams...)
+
+	cmd := exec.Command(
+		"argocd",
+		cmdParams...,
+	)
+	customEnv := []string{
+		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
+		fmt.Sprintf("ARGOCD_SERVER=%s", config.Config.Argo.Environments[env].ServerName),
+	}
+
+	cmd.Env = append(os.Environ(), customEnv...)
+	cmd.Stdout = output.OutLogger{}
+	cmd.Stderr = output.ErrLogger{}
+	log.Debugf("running command %s", cmd.String())
+
+	err := cmd.Run()
+
+	if err != nil {
+		return fmt.Errorf("failed to wait for service %s: %w", service, err)
+	}
+
+	return nil
+}
+
+func Deploy(service config.ServiceName, tag string, env config.Environment, imageTagParameter string, shouldWait bool) error {
 	log.Infof("retrieving current tag for service %s from argo...", service)
 	serviceInfo, err := getServiceInfo(service, env, imageTagParameter)
 	if err != nil {
@@ -234,6 +271,15 @@ func Deploy(service config.ServiceName, tag string, env config.Environment, imag
 			return fmt.Errorf("deploy of service %s failed: %w", service, err)
 		}
 		log.Infof("override of service %s to tag %s complete", service, tag)
+	}
+
+	if shouldWait {
+		log.Infof("waiting for service %s to complete deployment...", service)
+		err = wait(service, env)
+		if err != nil {
+			return err
+		}
+		log.Infof("service %s is now synced and healthy", service)
 	}
 
 	return nil

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moveaxlab/deploy1/tag"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 )
 
 func checkNoError(err error) {
@@ -68,10 +69,14 @@ var buildCmd = &cobra.Command{
 		}
 
 		if buildConfig.deploy {
+			var g errgroup.Group
 			for _, service := range services {
-				err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
-				checkNoError(err)
+				service := service
+				g.Go(func() error {
+					return argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
+				})
 			}
+			checkNoError(g.Wait())
 		}
 	},
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -34,6 +34,9 @@ var buildCmd = &cobra.Command{
 		buildConfig, err := getBuildFlags(cmd)
 		checkNoError(err)
 
+		deployFlags, err := getDeployFlags(cmd)
+		checkNoError(err)
+
 		actualTag, err := tag.GetTag(baseConfig.tag)
 		checkNoError(err)
 
@@ -66,7 +69,7 @@ var buildCmd = &cobra.Command{
 
 		if buildConfig.deploy {
 			for _, service := range services {
-				err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service))
+				err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
 				checkNoError(err)
 			}
 		}
@@ -78,4 +81,5 @@ func init() {
 	addDebugFlag(buildCmd)
 	addBaseFlags(buildCmd)
 	addBuildFlags(buildCmd)
+	addDeployFlags(buildCmd)
 }

--- a/cmd/build_all.go
+++ b/cmd/build_all.go
@@ -23,6 +23,9 @@ var buildAllCmd = &cobra.Command{
 		buildConfig, err := getBuildFlags(cmd)
 		checkNoError(err)
 
+		deployFlags, err := getDeployFlags(cmd)
+		checkNoError(err)
+
 		actualTag, err := tag.GetTag(baseConfig.tag)
 		checkNoError(err)
 
@@ -52,7 +55,7 @@ var buildAllCmd = &cobra.Command{
 
 		if buildConfig.deploy {
 			for _, service := range config.GetAllServices() {
-				err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service))
+				err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
 				checkNoError(err)
 			}
 		}
@@ -64,4 +67,5 @@ func init() {
 	addDebugFlag(buildAllCmd)
 	addBaseFlags(buildAllCmd)
 	addBuildFlags(buildAllCmd)
+	addDeployFlags(buildAllCmd)
 }

--- a/cmd/build_all.go
+++ b/cmd/build_all.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"golang.org/x/sync/errgroup"
+
 	"github.com/moveaxlab/deploy1/argo"
 	"github.com/moveaxlab/deploy1/bundle"
 	"github.com/moveaxlab/deploy1/config"
@@ -54,10 +56,14 @@ var buildAllCmd = &cobra.Command{
 		}
 
 		if buildConfig.deploy {
+			var g errgroup.Group
 			for _, service := range config.GetAllServices() {
-				err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
-				checkNoError(err)
+				service := service
+				g.Go(func() error {
+					return argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
+				})
 			}
+			checkNoError(g.Wait())
 		}
 	},
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -39,7 +39,7 @@ var deployCmd = &cobra.Command{
 					continue
 				}
 			}
-			err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service))
+			err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
 			checkNoError(err)
 		}
 	},

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/moveaxlab/deploy1/tag"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 )
 
 var deployCmd = &cobra.Command{
@@ -30,18 +31,26 @@ var deployCmd = &cobra.Command{
 		actualTag, err := tag.GetTag(baseConfig.tag)
 		checkNoError(err)
 
+		var g errgroup.Group
 		for _, service := range services {
-			if !deployFlags.noImageTagCheck {
-				tagExists, err := docker.TagExists(service, baseConfig.env, actualTag)
-				checkNoError(err)
-				if !tagExists {
-					log.Infof("skipping deployment of service %s: tag %s does not exist", service, actualTag)
-					continue
+			service := service
+			g.Go(func() error {
+
+				if !deployFlags.noImageTagCheck {
+					tagExists, err := docker.TagExists(service, baseConfig.env, actualTag)
+					if err != nil {
+						return err
+					}
+					if !tagExists {
+						log.Infof("skipping deployment of service %s: tag %s does not exist", service, actualTag)
+						return nil
+					}
 				}
-			}
-			err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
-			checkNoError(err)
+				return argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
+			})
 		}
+
+		checkNoError(g.Wait())
 	},
 }
 

--- a/cmd/deploy_all.go
+++ b/cmd/deploy_all.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"golang.org/x/sync/errgroup"
+
 	"github.com/moveaxlab/deploy1/argo"
 	"github.com/moveaxlab/deploy1/config"
 	"github.com/moveaxlab/deploy1/docker"
@@ -25,18 +27,25 @@ var deployAllCmd = &cobra.Command{
 		deployFlags, err := getDeployFlags(cmd)
 		checkNoError(err)
 
+		var g errgroup.Group
 		for _, service := range config.GetAllServices() {
-			if !deployFlags.noImageTagCheck {
-				tagExists, err := docker.TagExists(service, baseConfig.env, actualTag)
-				checkNoError(err)
-				if !tagExists {
-					log.Infof("skipping deployment of service %s: tag %s does not exist", service, actualTag)
-					continue
+			service := service
+			g.Go(func() error {
+				if !deployFlags.noImageTagCheck {
+					tagExists, err := docker.TagExists(service, baseConfig.env, actualTag)
+					if err != nil {
+						return err
+					}
+					if !tagExists {
+						log.Infof("skipping deployment of service %s: tag %s does not exist", service, actualTag)
+						return nil
+					}
 				}
-			}
-			err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
-			checkNoError(err)
+				return argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
+			})
 		}
+
+		checkNoError(g.Wait())
 	},
 }
 

--- a/cmd/deploy_all.go
+++ b/cmd/deploy_all.go
@@ -34,7 +34,7 @@ var deployAllCmd = &cobra.Command{
 					continue
 				}
 			}
-			err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service))
+			err = argo.Deploy(config.GetServiceName(service, baseConfig.env), actualTag, baseConfig.env, config.GetImageTagParameter(service), deployFlags.wait)
 			checkNoError(err)
 		}
 	},

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/moveaxlab/deploy1/config"
 	"github.com/moveaxlab/deploy1/tag"
 	log "github.com/sirupsen/logrus"
@@ -17,6 +18,7 @@ const (
 	noBundleFlag    = "no-bundle"
 	noCacheFlag     = "no-cache"
 	noImageTagCheck = "no-image-tag-check"
+	waitFlag        = "wait"
 )
 
 func addDebugFlag(cmd *cobra.Command) {
@@ -147,10 +149,17 @@ func addDeployFlags(cmd *cobra.Command) {
 		false,
 		"skip image tag check before deployment (use at your own risk)",
 	)
+
+	cmd.Flags().Bool(
+		waitFlag,
+		false,
+		"wait for service to be fully deployed (synced and healthy)",
+	)
 }
 
 type deployFlags struct {
 	noImageTagCheck bool
+	wait            bool
 }
 
 func getDeployFlags(cmd *cobra.Command) (*deployFlags, error) {
@@ -159,7 +168,13 @@ func getDeployFlags(cmd *cobra.Command) (*deployFlags, error) {
 		return nil, fmt.Errorf("invalid image tag check flag: %w", err)
 	}
 
+	wait, err := cmd.Flags().GetBool(waitFlag)
+	if err != nil {
+		return nil, fmt.Errorf("invalid wait flag: %w", err)
+	}
+
 	return &deployFlags{
 		noImageTagCheck: noImageTagCheck,
+		wait:            wait,
 	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.0.0-20201013081832-0aaa2718063a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,10 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
With this option we can check directly from the terminal when the pod is up and running instead of switching to argo