### PR TITLE
[Feature] reset image tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`deploy1` is a Go CLI tool that builds Docker images and deploys them via ArgoCD. It wraps `docker build/push` and the `argocd` CLI, driven by a `deploy1.json` config file in the consumer project root.
+
+## Commands
+
+```bash
+go build ./...          # compile
+go test ./...           # run all tests (only utils/ has tests currently)
+go vet ./...            # static analysis
+./lint.sh               # gofmt check (run before committing)
+```
+
+`mise install` pins Go to 1.19 (see `.mise.toml`). CI runs `go vet`, `./lint.sh`, and `go test`.
+
+## Architecture
+
+The CLI is built with [cobra](https://github.com/spf13/cobra). Entry point: `main.go` → `cmd.Execute()`.
+
+**Package layout:**
+
+| Package | Responsibility |
+|---------|---------------|
+| `cmd/` | Cobra command definitions (`build`, `build-all`, `deploy`, `deploy-all`, `reset`); flag parsing in `flags.go` |
+| `config/` | Loads `./deploy1.json` at init time into `config.Config`; exposes typed accessors for services, registry, argo, scripts |
+| `tag/` | Resolves the Docker image tag: explicit `--tag` → `"dev"` on `dev` branch → task ID extracted from branch name (regex `[A-Z]+-[0-9]+`) |
+| `git/` | Reads current branch name via `git` |
+| `utils/` | `GetTaskName` regex helper; has the only unit tests |
+| `bundle/` | Runs `prepare_bundle`, per-service `bundle`, and `post_bundle` scripts |
+| `docker/` | Wraps `docker build`, `docker push`, `docker inspect` (hash), and `docker manifest inspect` (tag existence check) |
+| `argo/` | Wraps `argocd` CLI: `app get` (reads current tag + resource kind), `app set` (helm override), `app unset` (remove override), `app actions run restart`, `app wait` |
+| `output/` | `io.Writer` adapters that pipe subprocess stdout/stderr through logrus |
+
+**Build flow** (`deploy1 build <svc>`):
+1. Run `prepare_bundle` script once
+2. For each service: run per-service `bundle` script → `docker build` → `docker push`
+3. Run `post_bundle` cleanup script
+4. If `--deploy`: run ArgoCD deploys in parallel via `errgroup`
+
+**Deploy logic** (`argo.Deploy`): fetches the service's current Helm image tag from ArgoCD. If the tag is unchanged, it calls `argocd app actions run restart` (rolling restart); if the tag differs, it calls `argocd app set --helm-set-string image.tag=<tag>`. With `--wait`, it additionally calls `argocd app wait --health --sync`.
+
+**Reset logic** (`argo.Reset`): calls `argocd app unset -p image.tag` (or the service's custom `imageTagParameter`) to remove the Helm override, reverting the service to its chart default tag. Accepts one or more services; runs in parallel. Supports `--wait`. Note: ArgoCD v2.7.1 uses `-p <key>` (not `--helm-set-string`) on the `unset` subcommand.
+
+**Flag groups** (`cmd/flags.go`): each command family owns its flag group — `addBaseFlags`/`getBaseFlags` (tag + env, for build/deploy), `addBuildFlags`/`getBuildFlags`, `addDeployFlags`/`getDeployFlags`, `addResetFlags`/`getResetFlags` (env + wait, for reset). `ValidateEnvironment` checks `Config.Registry.Environments`; Argo environments are accessed directly via `Config.Argo.Environments[env]` and are not independently validated.
+
+**ArgoCD auth**: credentials are never hardcoded. The `ARGOCD_AUTH_TOKEN` and `ARGOCD_SERVER` env vars are set per-command from the environment variable names listed in `deploy1.json` (`argo.environments.<env>.auth_token`).
+
+**Config loading**: `config.init()` reads `./deploy1.json` relative to the working directory where `deploy1` is run (the consumer project root, not this repo).

--- a/README.md
+++ b/README.md
@@ -249,6 +249,19 @@ When the `--wait` flag is used, deploy1 will:
 - Report when the service is ready
 
 It can also be used in combination with deploy flag when doing a build and deploy in one shot.
+
+### Resetting image tag overrides
+
+When you deploy a service with a custom tag, ArgoCD stores that tag as a Helm override.
+To remove the override and revert one or more services to their default tag, use:
+
+```bash
+deploy1 reset <service 1> <service 2> ...
+```
+
+You can specify which environment to reset using the `--env` flag.
+If you don't specify an environment, the `default_environment` will be used.
+
 ## Extras
 
 There's an attempt at support for shell completion.

--- a/argo/reset.go
+++ b/argo/reset.go
@@ -1,0 +1,62 @@
+package argo
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/moveaxlab/deploy1/config"
+	"github.com/moveaxlab/deploy1/output"
+	log "github.com/sirupsen/logrus"
+)
+
+func Reset(service config.ServiceName, env config.Environment, imageTagParameter string, shouldWait bool) error {
+	param := defaultImageTagParameter
+	if imageTagParameter != "" {
+		param = parameterName(imageTagParameter)
+	}
+
+	log.Infof("removing image tag override for service %s...", service)
+
+	extraParams := config.Config.Argo.Environments[env].ArgoExtraParams
+
+	cmdParams := append([]string{
+		"--grpc-web",
+		"app",
+		"unset",
+		string(service),
+		"-p", string(param),
+	},
+		extraParams...)
+
+	cmd := exec.Command(
+		"argocd",
+		cmdParams...,
+	)
+	customEnv := []string{
+		fmt.Sprintf("ARGOCD_AUTH_TOKEN=%s", os.Getenv(config.Config.Argo.Environments[env].AuthTokenEnvVariable)),
+		fmt.Sprintf("ARGOCD_SERVER=%s", config.Config.Argo.Environments[env].ServerName),
+	}
+	cmd.Env = append(os.Environ(), customEnv...)
+	cmd.Stdout = output.OutLogger{}
+	cmd.Stderr = output.ErrLogger{}
+	log.Debugf("running command %s", cmd.String())
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to reset image tag for service %s: %w", service, err)
+	}
+
+	log.Infof("image tag override for service %s removed", service)
+
+	if shouldWait {
+		log.Infof("waiting for service %s to complete deployment...", service)
+		err = wait(service, env)
+		if err != nil {
+			return err
+		}
+		log.Infof("service %s is now synced and healthy", service)
+	}
+
+	return nil
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -143,42 +143,6 @@ func getBuildFlags(cmd *cobra.Command) (*buildArgs, error) {
 	}, nil
 }
 
-func addEnvFlag(cmd *cobra.Command) {
-	cmd.Flags().String(
-		envFlag,
-		string(config.Config.DefaultEnvironment),
-		"environment for deploy",
-	)
-
-	_ = cmd.RegisterFlagCompletionFunc(envFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return config.AutocompleteEnvironment(toComplete), cobra.ShellCompDirectiveDefault
-	})
-}
-
-func getEnvFlag(cmd *cobra.Command) (config.Environment, error) {
-	rawEnv, err := cmd.Flags().GetString(envFlag)
-	if err != nil {
-		return "", fmt.Errorf("invalid env: %w", err)
-	}
-	return config.ValidateEnvironment(rawEnv)
-}
-
-func addWaitFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool(
-		waitFlag,
-		false,
-		"wait for service to be fully deployed (synced and healthy)",
-	)
-}
-
-func getWaitFlag(cmd *cobra.Command) (bool, error) {
-	wait, err := cmd.Flags().GetBool(waitFlag)
-	if err != nil {
-		return false, fmt.Errorf("invalid wait flag: %w", err)
-	}
-	return wait, nil
-}
-
 func addDeployFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(
 		noImageTagCheck,
@@ -213,4 +177,46 @@ func getDeployFlags(cmd *cobra.Command) (*deployFlags, error) {
 		noImageTagCheck: noImageTagCheck,
 		wait:            wait,
 	}, nil
+}
+
+func addResetFlags(cmd *cobra.Command) {
+	cmd.Flags().String(
+		envFlag,
+		string(config.Config.DefaultEnvironment),
+		"environment for reset",
+	)
+
+	_ = cmd.RegisterFlagCompletionFunc(envFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return config.AutocompleteEnvironment(toComplete), cobra.ShellCompDirectiveDefault
+	})
+
+	cmd.Flags().Bool(
+		waitFlag,
+		false,
+		"wait for service to be fully deployed (synced and healthy)",
+	)
+}
+
+type resetFlags struct {
+	env  config.Environment
+	wait bool
+}
+
+func getResetFlags(cmd *cobra.Command) (*resetFlags, error) {
+	rawEnv, err := cmd.Flags().GetString(envFlag)
+	if err != nil {
+		return nil, fmt.Errorf("invalid env: %w", err)
+	}
+
+	env, err := config.ValidateEnvironment(rawEnv)
+	if err != nil {
+		return nil, fmt.Errorf("invalid env: %w", err)
+	}
+
+	wait, err := cmd.Flags().GetBool(waitFlag)
+	if err != nil {
+		return nil, fmt.Errorf("invalid wait flag: %w", err)
+	}
+
+	return &resetFlags{env: env, wait: wait}, nil
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -143,6 +143,42 @@ func getBuildFlags(cmd *cobra.Command) (*buildArgs, error) {
 	}, nil
 }
 
+func addEnvFlag(cmd *cobra.Command) {
+	cmd.Flags().String(
+		envFlag,
+		string(config.Config.DefaultEnvironment),
+		"environment for deploy",
+	)
+
+	_ = cmd.RegisterFlagCompletionFunc(envFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return config.AutocompleteEnvironment(toComplete), cobra.ShellCompDirectiveDefault
+	})
+}
+
+func getEnvFlag(cmd *cobra.Command) (config.Environment, error) {
+	rawEnv, err := cmd.Flags().GetString(envFlag)
+	if err != nil {
+		return "", fmt.Errorf("invalid env: %w", err)
+	}
+	return config.ValidateEnvironment(rawEnv)
+}
+
+func addWaitFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool(
+		waitFlag,
+		false,
+		"wait for service to be fully deployed (synced and healthy)",
+	)
+}
+
+func getWaitFlag(cmd *cobra.Command) (bool, error) {
+	wait, err := cmd.Flags().GetBool(waitFlag)
+	if err != nil {
+		return false, fmt.Errorf("invalid wait flag: %w", err)
+	}
+	return wait, nil
+}
+
 func addDeployFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool(
 		noImageTagCheck,

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"golang.org/x/sync/errgroup"
+
+	"github.com/moveaxlab/deploy1/argo"
+	"github.com/moveaxlab/deploy1/config"
+	"github.com/spf13/cobra"
+)
+
+var resetCmd = &cobra.Command{
+	Use:   "reset (SERVICE ...)",
+	Short: "Remove image tag overrides for one or more services",
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return config.AutocompleteService(args, toComplete), cobra.ShellCompDirectiveNoFileComp
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		applyDebugFlag(cmd)
+
+		services, err := config.ValidateServiceName(args)
+		checkNoError(err)
+
+		env, err := getEnvFlag(cmd)
+		checkNoError(err)
+
+		shouldWait, err := getWaitFlag(cmd)
+		checkNoError(err)
+
+		var g errgroup.Group
+		for _, service := range services {
+			service := service
+			g.Go(func() error {
+				return argo.Reset(config.GetServiceName(service, env), env, config.GetImageTagParameter(service), shouldWait)
+			})
+		}
+
+		checkNoError(g.Wait())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(resetCmd)
+	addDebugFlag(resetCmd)
+	addEnvFlag(resetCmd)
+	addWaitFlag(resetCmd)
+}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -20,17 +20,14 @@ var resetCmd = &cobra.Command{
 		services, err := config.ValidateServiceName(args)
 		checkNoError(err)
 
-		env, err := getEnvFlag(cmd)
-		checkNoError(err)
-
-		shouldWait, err := getWaitFlag(cmd)
+		resetConfig, err := getResetFlags(cmd)
 		checkNoError(err)
 
 		var g errgroup.Group
 		for _, service := range services {
 			service := service
 			g.Go(func() error {
-				return argo.Reset(config.GetServiceName(service, env), env, config.GetImageTagParameter(service), shouldWait)
+				return argo.Reset(config.GetServiceName(service, resetConfig.env), resetConfig.env, config.GetImageTagParameter(service), resetConfig.wait)
 			})
 		}
 
@@ -41,6 +38,5 @@ var resetCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(resetCmd)
 	addDebugFlag(resetCmd)
-	addEnvFlag(resetCmd)
-	addWaitFlag(resetCmd)
+	addResetFlags(resetCmd)
 }


### PR DESCRIPTION
  **Problem**: [Feature Request: Add ability to reset/revert image tag overrides for multiple services #3](https://github.com/moveaxlab/deploy1/issues/3)
  
  **Solution**: 
  New reset command that removes ArgoCD Helm image tag overrides for one or more services, reverting them to the default tag.

` deploy1 reset <service 1> <service 2> ... [--env <env>] [--wait]`

  - Runs resets in parallel via errgroup, same as deploy
  - Respects custom image_tag_parameter from service config
  - --wait blocks until ArgoCD reports synced and healthy
  - Note: ArgoCD v2.7.x app unset uses -p <key>, not --helm-set-string